### PR TITLE
Update code to work with Searchbar and multiple views.

### DIFF
--- a/dist/framework7.upscroller.js
+++ b/dist/framework7.upscroller.js
@@ -9,11 +9,12 @@ Framework7.prototype.plugins.upscroller = function (app, params) {
 			pageBeforeInit: function (pageData) {				
 				var $$btn = $$('<div class="upscroller">↑ ' + params.text + '</div>');				
 				$$(pageData.container).prepend($$btn);
+				if ($$("[data-page='"+pageData.name+"'] > .searchbar")[0]) $$("[data-page='"+pageData.name+"'] >  .upscroller").css('top', '-10px');
 				
 				$$btn.click(function(event) {
 					event.stopPropagation();
 				    event.preventDefault();
-				    var curpage = $$(".page-content", mainView.activePage.container);				
+				    var curpage = $$(".page-content", app.getCurrentView().activePage.container);				
 				    $$(curpage).scrollTop(0, Math.round($$(curpage).scrollTop()/4));
 				});
 				


### PR DESCRIPTION
### Line 11 (add):

``` javascript
if ($$("[data-page='"+pageData.name+"'] > .searchbar")[0]) $$("[data-page='"+pageData.name+"'] >  .upscroller").css('top', '-10px');
```

this will make the upscroller div appear below the Searchbar not over it.
### Line 17 (change):

``` javascript
var curpage = $$(".page-content", app.getCurrentView().activePage.container);
```

this will help the plugin to work with multiple views apps
